### PR TITLE
插件新增数据导出功能

### DIFF
--- a/.github/workflows/gradle-dev.yml
+++ b/.github/workflows/gradle-dev.yml
@@ -1,0 +1,33 @@
+name: Build eCaptureBurp Extension
+
+on:
+  push:
+    branches: [ 'dev' ]
+  pull_request:
+    branches: [ 'dev' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew jar
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ecapture-burp-extension
+        path: build/libs/ecapture-burp-extension-1.1.0.jar

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,33 @@
+name: Build eCaptureBurp Extension
+
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ 'main' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew jar
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ecapture-burp-extension
+        path: build/libs/ecapture-burp-extension-1.0.0.jar

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,13 @@ dependencies {
     
     // Protobuf runtime (for parsing)
     implementation 'com.google.protobuf:protobuf-java:3.25.1'
+
+    // Gson for JSON/HAR serialization
+    implementation 'com.google.code.gson:gson:2.10.1'
+
+    // Apache POI for Excel export
+    implementation 'org.apache.poi:poi:5.2.3'
+    implementation 'org.apache.poi:poi-ooxml:5.2.3'
 }
 
 jar {

--- a/src/main/java/com/ecapture/burp/event/MatchedHttpPair.java
+++ b/src/main/java/com/ecapture/burp/event/MatchedHttpPair.java
@@ -158,6 +158,38 @@ public class MatchedHttpPair {
         return port == 443 || port == 8443;
     }
     
+    /**
+     * Get protocol string: HTTP/1.x or HTTP/2 if detectable from events.
+     */
+    public String getProtocol() {
+        // Prefer request's eventType if available
+        if (request != null) {
+            switch (request.getEventType()) {
+                case HTTP2_REQUEST:
+                case AUTO_REQUEST:
+                    return "HTTP/2";
+                case HTTP1_REQUEST:
+                    return "HTTP/1.x";
+                default:
+                    break;
+            }
+        }
+        if (response != null) {
+            switch (response.getEventType()) {
+                case HTTP2_RESPONSE:
+                case AUTO_RESPONSE:
+                    return "HTTP/2";
+                case HTTP1_RESPONSE:
+                    return "HTTP/1.x";
+                default:
+                    break;
+            }
+        }
+        // fallback to port heuristic or content
+        if (isHttps()) return "HTTPS";
+        return "Unknown";
+    }
+
     @Override
     public String toString() {
         return String.format("MatchedHttpPair[uuid=%s, method=%s, url=%s, status=%s, complete=%s]",

--- a/src/main/java/com/ecapture/burp/export/ExcelExporter.java
+++ b/src/main/java/com/ecapture/burp/export/ExcelExporter.java
@@ -30,6 +30,7 @@ public class ExcelExporter {
                 switch (col) {
                     case "#": value = pair.getUuid(); break;
                     case "Time": value = pair.getTimestamp(); break;
+                    case "Proto": value = pair.getProtocol(); break;
                     case "Method": value = pair.getMethod(); break;
                     case "Host": value = pair.getHost(); break;
                     case "URL": value = pair.getUrl(); break;

--- a/src/main/java/com/ecapture/burp/export/ExcelExporter.java
+++ b/src/main/java/com/ecapture/burp/export/ExcelExporter.java
@@ -1,0 +1,102 @@
+package com.ecapture.burp.export;
+
+import com.ecapture.burp.event.MatchedHttpPair;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Simple Excel exporter using Apache POI.
+ */
+public class ExcelExporter {
+
+    public static void writeXlsx(OutputStream out, List<MatchedHttpPair> pairs, List<String> columns) throws Exception {
+        try (Workbook wb = new XSSFWorkbook()) {
+            CreationHelper createHelper = wb.getCreationHelper();
+            Sheet sheet = wb.createSheet("eCapture");
+
+            int rowIdx = 0;
+            // Header
+            Row header = sheet.createRow(rowIdx++);
+            for (int c = 0; c < columns.size(); c++) {
+                Cell cell = header.createCell(c);
+                cell.setCellValue(columns.get(c));
+            }
+
+            // Rows
+            for (MatchedHttpPair pair : pairs) {
+                Row r = sheet.createRow(rowIdx++);
+                for (int c = 0; c < columns.size(); c++) {
+                    String col = columns.get(c);
+                    Cell cell = r.createCell(c);
+                    switch (col) {
+                        case "#":
+                            cell.setCellValue(pair.getUuid());
+                            break;
+                        case "Time":
+                            cell.setCellValue(pair.getTimestamp());
+                            break;
+                        case "Method":
+                            cell.setCellValue(pair.getMethod());
+                            break;
+                        case "Host":
+                            cell.setCellValue(pair.getHost());
+                            break;
+                        case "URL":
+                            cell.setCellValue(pair.getUrl());
+                            break;
+                        case "Status":
+                            cell.setCellValue(pair.getStatusCode());
+                            break;
+                        case "Req Len":
+                            cell.setCellValue(pair.getRequestLength());
+                            break;
+                        case "Resp Len":
+                            cell.setCellValue(pair.getResponseLength());
+                            break;
+                        case "Process":
+                            cell.setCellValue(pair.getProcessInfo());
+                            break;
+                        case "Complete":
+                            cell.setCellValue(pair.isComplete() ? "✓" : "...");
+                            break;
+                        case "Request Body":
+                            if (pair.getRequest() != null && pair.getRequest().getPayload() != null) {
+                                byte[] p = pair.getRequest().getPayload();
+                                cell.setCellValue(new String(p, StandardCharsets.UTF_8));
+                            } else {
+                                cell.setCellValue("");
+                            }
+                            break;
+                        case "Response Body":
+                            if (pair.getResponse() != null && pair.getResponse().getPayload() != null) {
+                                byte[] p = pair.getResponse().getPayload();
+                                cell.setCellValue(new String(p, StandardCharsets.UTF_8));
+                            } else {
+                                cell.setCellValue("");
+                            }
+                            break;
+                        default:
+                            cell.setCellValue("");
+                    }
+                }
+            }
+
+            // Auto-size first few columns
+            for (int c = 0; c < Math.min(10, columns.size()); c++) {
+                sheet.autoSizeColumn(c);
+            }
+
+            wb.write(out);
+        }
+    }
+}
+

--- a/src/main/java/com/ecapture/burp/export/ExportManager.java
+++ b/src/main/java/com/ecapture/burp/export/ExportManager.java
@@ -1,0 +1,30 @@
+package com.ecapture.burp.export;
+
+import com.ecapture.burp.event.MatchedHttpPair;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.List;
+
+/**
+ * High level export manager that delegates to HAR and CSV exporters.
+ */
+public class ExportManager {
+
+    public ExportManager() {
+    }
+
+    public void exportAsHar(File outFile, List<MatchedHttpPair> pairs, List<String> columns) throws Exception {
+        try (FileOutputStream fos = new FileOutputStream(outFile)) {
+            HarSerializer.writeHar(fos, pairs, columns);
+        }
+    }
+
+    public void exportAsExcel(File outFile, List<MatchedHttpPair> pairs, List<String> columns) throws Exception {
+        try (FileOutputStream fos = new FileOutputStream(outFile)) {
+            // ExcelExporter writes CSV text for compatibility; if user selected .xlsx extension, file will contain CSV
+            ExcelExporter.writeXlsx(fos, pairs, columns);
+        }
+    }
+}
+

--- a/src/main/java/com/ecapture/burp/export/HarSerializer.java
+++ b/src/main/java/com/ecapture/burp/export/HarSerializer.java
@@ -1,11 +1,6 @@
 package com.ecapture.burp.export;
 
-import com.ecapture.burp.event.CapturedEvent;
 import com.ecapture.burp.event.MatchedHttpPair;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -16,105 +11,94 @@ import java.util.Base64;
 import java.util.List;
 
 /**
- * Minimal HAR serializer producing HAR 1.2 compatible JSON.
+ * Minimal HAR serializer implemented without external JSON libraries.
  */
 public class HarSerializer {
 
-    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-
     public static void writeHar(OutputStream out, List<MatchedHttpPair> pairs, List<String> columns) throws Exception {
-        JsonObject root = new JsonObject();
-        JsonObject log = new JsonObject();
-        log.addProperty("version", "1.2");
-        JsonObject creator = new JsonObject();
-        creator.addProperty("name", "eCaptureBurp");
-        creator.addProperty("version", "1.0");
-        log.add("creator", creator);
-
-        JsonArray entries = new JsonArray();
-
+        StringBuilder sb = new StringBuilder();
         DateTimeFormatter fmt = DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC);
 
+        sb.append("{");
+        sb.append("\"log\":{");
+        sb.append("\"version\":\"1.2\",");
+        sb.append("\"creator\":{\"name\":\"eCaptureBurp\",\"version\":\"1.0\"},");
+        sb.append("\"entries\":[");
+
+        boolean firstEntry = true;
         for (MatchedHttpPair pair : pairs) {
-            JsonObject entry = new JsonObject();
+            if (!firstEntry) sb.append(',');
+            firstEntry = false;
+
+            sb.append('{');
             long startedMillis = pair.getCreatedAt();
-            entry.addProperty("startedDateTime", fmt.format(Instant.ofEpochMilli(startedMillis)));
-            entry.addProperty("time", 0);
+            sb.append("\"startedDateTime\":\"").append(escape(fmt.format(Instant.ofEpochMilli(startedMillis)))).append("\",");
+            sb.append("\"time\":0,");
 
             // request
-            JsonObject request = new JsonObject();
-            request.addProperty("method", pair.getMethod());
-            request.addProperty("url", pair.getUrl());
-            request.addProperty("httpVersion", "HTTP/1.1");
-            // headers - best effort: include Host
-            JsonArray reqHeaders = new JsonArray();
-            JsonObject hostHeader = new JsonObject();
-            hostHeader.addProperty("name", "Host");
-            hostHeader.addProperty("value", pair.getHost());
-            reqHeaders.add(hostHeader);
-            request.add("headers", reqHeaders);
-            request.addProperty("headersSize", -1);
-            request.addProperty("bodySize", pair.getRequestLength());
+            sb.append("\"request\":{");
+            sb.append("\"method\":\"").append(escape(pair.getMethod())).append("\",");
+            sb.append("\"url\":\"").append(escape(pair.getUrl())).append("\",");
+            sb.append("\"httpVersion\":\"HTTP/1.1\",");
+            sb.append("\"headers\":[{" + "\"name\":\"Host\",\"value\":\"" + escape(pair.getHost()) + "\"}],");
+            sb.append("\"headersSize\":-1,");
+            sb.append("\"bodySize\":").append(pair.getRequestLength());
 
-            // postData if available
+            // postData
             if (pair.getRequest() != null && pair.getRequest().getPayload() != null) {
                 byte[] payload = pair.getRequest().getPayload();
-                String text = null;
-                JsonObject postData = new JsonObject();
-                boolean binary = false;
-                try {
-                    text = new String(payload, StandardCharsets.UTF_8);
-                    // crude check for non-text
-                    if (!isMostlyText(payload)) {
-                        binary = true;
-                    }
-                } catch (Exception e) {
-                    binary = true;
-                }
+                boolean binary = !isMostlyText(payload);
+                sb.append(',');
+                sb.append("\"postData\":{");
                 if (binary) {
-                    postData.addProperty("mimeType", "application/octet-stream");
-                    postData.addProperty("text", Base64.getEncoder().encodeToString(payload));
-                    postData.addProperty("encoding", "base64");
+                    sb.append("\"mimeType\":\"application/octet-stream\",");
+                    sb.append("\"text\":\"").append(Base64.getEncoder().encodeToString(payload)).append("\",");
+                    sb.append("\"encoding\":\"base64\"");
                 } else {
-                    postData.addProperty("mimeType", "text/plain");
-                    postData.addProperty("text", text);
+                    String text = new String(payload, StandardCharsets.UTF_8);
+                    sb.append("\"mimeType\":\"text/plain\",");
+                    sb.append("\"text\":\"").append(escape(text)).append("\"");
                 }
-                request.add("postData", postData);
+                sb.append('}');
             }
 
+            sb.append('}'); // end request
+            sb.append(',');
+
             // response
-            JsonObject response = new JsonObject();
-            response.addProperty("status", parseStatus(pair.getStatusCode()));
-            response.addProperty("statusText", "");
-            response.addProperty("httpVersion", "HTTP/1.1");
-            response.add("headers", new JsonArray());
-            response.addProperty("headersSize", -1);
-            response.addProperty("bodySize", pair.getResponseLength());
+            sb.append("\"response\":{");
+            sb.append("\"status\":").append(parseStatus(pair.getStatusCode())).append(',');
+            sb.append("\"statusText\":\"\",");
+            sb.append("\"httpVersion\":\"HTTP/1.1\",");
+            sb.append("\"headers\":[],");
+            sb.append("\"headersSize\":-1,");
+            sb.append("\"bodySize\":").append(pair.getResponseLength());
+
             if (pair.getResponse() != null && pair.getResponse().getPayload() != null) {
                 byte[] payload = pair.getResponse().getPayload();
                 boolean binary = !isMostlyText(payload);
-                JsonObject content = new JsonObject();
-                content.addProperty("size", payload.length);
-                content.addProperty("mimeType", "application/octet-stream");
+                sb.append(',');
+                sb.append("\"content\":{");
+                sb.append("\"size\":").append(payload.length).append(',');
+                sb.append("\"mimeType\":\"application/octet-stream\",");
                 if (binary) {
-                    content.addProperty("text", Base64.getEncoder().encodeToString(payload));
-                    content.addProperty("encoding", "base64");
+                    sb.append("\"text\":\"").append(Base64.getEncoder().encodeToString(payload)).append("\",");
+                    sb.append("\"encoding\":\"base64\"");
                 } else {
-                    content.addProperty("text", new String(payload, StandardCharsets.UTF_8));
+                    sb.append("\"text\":\"").append(escape(new String(payload, StandardCharsets.UTF_8))).append("\"");
                 }
-                response.add("content", content);
+                sb.append('}');
             }
 
-            entry.add("request", request);
-            entry.add("response", response);
-            entries.add(entry);
+            sb.append('}'); // end response
+
+            sb.append('}'); // end entry
         }
 
-        log.add("entries", entries);
-        root.add("log", log);
+        sb.append("]}");
+        sb.append('}');
 
-        String json = GSON.toJson(root);
-        out.write(json.getBytes(StandardCharsets.UTF_8));
+        out.write(sb.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     private static boolean isMostlyText(byte[] data) {
@@ -135,5 +119,27 @@ public class HarSerializer {
             return 0;
         }
     }
-}
 
+    // very small JSON string escaper
+    private static String escape(String s) {
+        if (s == null) return "";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '"': sb.append("\\\""); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int)c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/ecapture/burp/export/HarSerializer.java
+++ b/src/main/java/com/ecapture/burp/export/HarSerializer.java
@@ -90,7 +90,9 @@ public class HarSerializer {
                 sb.append('}');
             }
 
-            sb.append('}'); // end response
+            // add protocol as comment
+            sb.append(',');
+            sb.append("\"comment\":\"").append(escape(pair.getProtocol())).append("\"");
 
             sb.append('}'); // end entry
         }

--- a/src/main/java/com/ecapture/burp/export/HarSerializer.java
+++ b/src/main/java/com/ecapture/burp/export/HarSerializer.java
@@ -1,0 +1,139 @@
+package com.ecapture.burp.export;
+
+import com.ecapture.burp.event.CapturedEvent;
+import com.ecapture.burp.event.MatchedHttpPair;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Minimal HAR serializer producing HAR 1.2 compatible JSON.
+ */
+public class HarSerializer {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    public static void writeHar(OutputStream out, List<MatchedHttpPair> pairs, List<String> columns) throws Exception {
+        JsonObject root = new JsonObject();
+        JsonObject log = new JsonObject();
+        log.addProperty("version", "1.2");
+        JsonObject creator = new JsonObject();
+        creator.addProperty("name", "eCaptureBurp");
+        creator.addProperty("version", "1.0");
+        log.add("creator", creator);
+
+        JsonArray entries = new JsonArray();
+
+        DateTimeFormatter fmt = DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC);
+
+        for (MatchedHttpPair pair : pairs) {
+            JsonObject entry = new JsonObject();
+            long startedMillis = pair.getCreatedAt();
+            entry.addProperty("startedDateTime", fmt.format(Instant.ofEpochMilli(startedMillis)));
+            entry.addProperty("time", 0);
+
+            // request
+            JsonObject request = new JsonObject();
+            request.addProperty("method", pair.getMethod());
+            request.addProperty("url", pair.getUrl());
+            request.addProperty("httpVersion", "HTTP/1.1");
+            // headers - best effort: include Host
+            JsonArray reqHeaders = new JsonArray();
+            JsonObject hostHeader = new JsonObject();
+            hostHeader.addProperty("name", "Host");
+            hostHeader.addProperty("value", pair.getHost());
+            reqHeaders.add(hostHeader);
+            request.add("headers", reqHeaders);
+            request.addProperty("headersSize", -1);
+            request.addProperty("bodySize", pair.getRequestLength());
+
+            // postData if available
+            if (pair.getRequest() != null && pair.getRequest().getPayload() != null) {
+                byte[] payload = pair.getRequest().getPayload();
+                String text = null;
+                JsonObject postData = new JsonObject();
+                boolean binary = false;
+                try {
+                    text = new String(payload, StandardCharsets.UTF_8);
+                    // crude check for non-text
+                    if (!isMostlyText(payload)) {
+                        binary = true;
+                    }
+                } catch (Exception e) {
+                    binary = true;
+                }
+                if (binary) {
+                    postData.addProperty("mimeType", "application/octet-stream");
+                    postData.addProperty("text", Base64.getEncoder().encodeToString(payload));
+                    postData.addProperty("encoding", "base64");
+                } else {
+                    postData.addProperty("mimeType", "text/plain");
+                    postData.addProperty("text", text);
+                }
+                request.add("postData", postData);
+            }
+
+            // response
+            JsonObject response = new JsonObject();
+            response.addProperty("status", parseStatus(pair.getStatusCode()));
+            response.addProperty("statusText", "");
+            response.addProperty("httpVersion", "HTTP/1.1");
+            response.add("headers", new JsonArray());
+            response.addProperty("headersSize", -1);
+            response.addProperty("bodySize", pair.getResponseLength());
+            if (pair.getResponse() != null && pair.getResponse().getPayload() != null) {
+                byte[] payload = pair.getResponse().getPayload();
+                boolean binary = !isMostlyText(payload);
+                JsonObject content = new JsonObject();
+                content.addProperty("size", payload.length);
+                content.addProperty("mimeType", "application/octet-stream");
+                if (binary) {
+                    content.addProperty("text", Base64.getEncoder().encodeToString(payload));
+                    content.addProperty("encoding", "base64");
+                } else {
+                    content.addProperty("text", new String(payload, StandardCharsets.UTF_8));
+                }
+                response.add("content", content);
+            }
+
+            entry.add("request", request);
+            entry.add("response", response);
+            entries.add(entry);
+        }
+
+        log.add("entries", entries);
+        root.add("log", log);
+
+        String json = GSON.toJson(root);
+        out.write(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static boolean isMostlyText(byte[] data) {
+        int printable = 0;
+        int total = Math.min(data.length, 200);
+        for (int i = 0; i < total; i++) {
+            int b = data[i] & 0xff;
+            if (b >= 32 && b <= 126) printable++;
+            if (b == '\n' || b == '\r' || b == '\t') printable++;
+        }
+        return total == 0 || ((double) printable / total) > 0.8;
+    }
+
+    private static int parseStatus(String statusStr) {
+        try {
+            return Integer.parseInt(statusStr);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}
+

--- a/src/main/java/com/ecapture/burp/ui/ColumnSelectorDialog.java
+++ b/src/main/java/com/ecapture/burp/ui/ColumnSelectorDialog.java
@@ -1,0 +1,67 @@
+package com.ecapture.burp.ui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Dialog for selecting which columns to include in exports.
+ */
+public class ColumnSelectorDialog extends JDialog {
+
+    private final List<String> selected = new ArrayList<>();
+    private final java.util.List<JCheckBox> boxes = new ArrayList<>();
+
+    public ColumnSelectorDialog(Window owner, List<String> currentSelection, String[] allColumns) {
+        super(owner, "Choose Export Columns", ModalityType.APPLICATION_MODAL);
+        setLayout(new BorderLayout(8, 8));
+
+        JPanel center = new JPanel(new GridLayout(0, 1));
+        for (String col : allColumns) {
+            if ("Sel".equals(col)) continue; // don't expose selection column
+            JCheckBox cb = new JCheckBox(col, currentSelection.contains(col));
+            boxes.add(cb);
+            center.add(cb);
+        }
+        add(new JScrollPane(center), BorderLayout.CENTER);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton ok = new JButton("OK");
+        JButton cancel = new JButton("Cancel");
+        JButton selectAll = new JButton("Select All");
+        JButton deselectAll = new JButton("Deselect All");
+
+        ok.addActionListener(e -> {
+            selected.clear();
+            for (JCheckBox cb : boxes) {
+                if (cb.isSelected()) selected.add(cb.getText());
+            }
+            setVisible(false);
+            dispose();
+        });
+        cancel.addActionListener(e -> {
+            selected.clear();
+            setVisible(false);
+            dispose();
+        });
+        selectAll.addActionListener(e -> boxes.forEach(b -> b.setSelected(true)));
+        deselectAll.addActionListener(e -> boxes.forEach(b -> b.setSelected(false)));
+
+        buttons.add(selectAll);
+        buttons.add(deselectAll);
+        buttons.add(cancel);
+        buttons.add(ok);
+
+        add(buttons, BorderLayout.SOUTH);
+        setSize(320, 360);
+        setLocationRelativeTo(owner);
+    }
+
+    public List<String> getSelectedColumns() {
+        return new ArrayList<>(selected);
+    }
+}
+

--- a/src/main/java/com/ecapture/burp/ui/ECaptureTab.java
+++ b/src/main/java/com/ecapture/burp/ui/ECaptureTab.java
@@ -61,9 +61,9 @@ public class ECaptureTab {
     private final com.ecapture.burp.export.ExportManager exportManager = new com.ecapture.burp.export.ExportManager();
     private java.util.List<String> exportColumns = new java.util.ArrayList<>();
 
-    // Table columns
+    // Table columns (add Protocol column)
     private static final String[] COLUMN_NAMES = {
-            "#", "Time", "Method", "Host", "URL", "Status", "Req Len", "Resp Len", "Process", "Complete"
+            "#", "Time", "Proto", "Method", "Host", "URL", "Status", "Req Len", "Resp Len", "Process", "Complete"
     };
     
     // Map pair ID to table row index for updates
@@ -210,15 +210,16 @@ public class ECaptureTab {
         // Set column widths
         eventTable.getColumnModel().getColumn(0).setPreferredWidth(40);  // #
         eventTable.getColumnModel().getColumn(1).setPreferredWidth(120); // Time
-        eventTable.getColumnModel().getColumn(2).setPreferredWidth(60);  // Method
-        eventTable.getColumnModel().getColumn(3).setPreferredWidth(150); // Host
-        eventTable.getColumnModel().getColumn(4).setPreferredWidth(250); // URL
-        eventTable.getColumnModel().getColumn(5).setPreferredWidth(50);  // Status
-        eventTable.getColumnModel().getColumn(6).setPreferredWidth(60);  // Req Len
-        eventTable.getColumnModel().getColumn(7).setPreferredWidth(60);  // Resp Len
-        eventTable.getColumnModel().getColumn(8).setPreferredWidth(120); // Process
-        eventTable.getColumnModel().getColumn(9).setPreferredWidth(60);  // Complete
-        
+        eventTable.getColumnModel().getColumn(2).setPreferredWidth(60);  // Proto
+        eventTable.getColumnModel().getColumn(3).setPreferredWidth(60);  // Method
+        eventTable.getColumnModel().getColumn(4).setPreferredWidth(150); // Host
+        eventTable.getColumnModel().getColumn(5).setPreferredWidth(250); // URL
+        eventTable.getColumnModel().getColumn(6).setPreferredWidth(50);  // Status
+        eventTable.getColumnModel().getColumn(7).setPreferredWidth(60);  // Req Len
+        eventTable.getColumnModel().getColumn(8).setPreferredWidth(60);  // Resp Len
+        eventTable.getColumnModel().getColumn(9).setPreferredWidth(120); // Process
+        eventTable.getColumnModel().getColumn(10).setPreferredWidth(60);  // Complete
+
         // Row sorter for filtering
         tableSorter = new TableRowSorter<>(tableModel);
         eventTable.setRowSorter(tableSorter);
@@ -355,10 +356,10 @@ public class ECaptureTab {
             
             if (existingRow != null && existingRow < tableModel.getRowCount()) {
                 // Update existing row (response arrived)
-                tableModel.setValueAt(pair.getStatusCode(), existingRow, 5);
-                tableModel.setValueAt(pair.getResponseLength(), existingRow, 7);
-                tableModel.setValueAt(pair.isComplete() ? "✓" : "...", existingRow, 9);
-                
+                tableModel.setValueAt(pair.getStatusCode(), existingRow, 6);
+                tableModel.setValueAt(pair.getResponseLength(), existingRow, 8);
+                tableModel.setValueAt(pair.isComplete() ? "✓" : "...", existingRow, 10);
+
             } else {
                 // Add new row
                 int rowNum = tableModel.getRowCount();
@@ -366,6 +367,7 @@ public class ECaptureTab {
                 java.util.Vector<Object> rowData = new java.util.Vector<>();
                 rowData.add(rowNum + 1);
                 rowData.add(pair.getTimestamp());
+                rowData.add(pair.getProtocol());
                 rowData.add(pair.getMethod());
                 rowData.add(pair.getHost());
                 rowData.add(pair.getUrl());


### PR DESCRIPTION
由于该burp插件只能接收eCapture的ws数据，但是无法保存数据，所以增加了数据导出功能，功能如下：
1.在表格上方（Search 面板）应该看到新增按钮：Choose Columns、Export HAR、Export CSV。
2.选择若干行（多选）或不选择（导出全部会弹窗确认），点击 Export HAR 或 Export CSV，会弹出文件保存对话框以选择输出文件路径。
<img width="1900" height="198" alt="image" src="https://github.com/user-attachments/assets/cc6f9f9a-cf81-4768-8f06-c34d14d43778" />

关键设计与行为

1. 多选：

- 第一列为 Boolean，可直接勾选；点击表头第一列会在所有行间切换全选/反选。

- getSelectedPairs() 返回被勾选的 MatchedHttpPair 列表；如果没有选中任何行，导出时会弹窗询问是否导出全部。

2. 列选择：

- 点击 “Choose Columns” 打开 modal，可选择要导出的列（默认为表格中全部列，除去 Sel）。

3. 导出：

- HAR: 生成一个基本 HAR JSON（log.version、creator、entries），entry 包含 request/response 的 minimal 字段，body 二进制以 base64 编码并标注 encoding。

- Excel: 生成 XLSX，第一行为列头，后面每行为一条记录；列名与 ColumnSelectorDialog 中一致。

4. 默认导出文件名：

- 取 WebSocket URL 文本，替换掉非法文件名字符为下划线，然后附加时间戳 yyyyMMdd_HHmmss 和扩展名（.har 或 .xlsx）。

5. 错误处理与边界：

- 若没有勾选行，导出时弹窗询问是否导出全部。

- 对非常大的/二进制正文：HAR 会 base64 编码；Excel 将尝试写为文本（如果你需要更稳妥的二进制处理/截断或把正文拆到单独文件，可继续优化）。

- 如果写文件时遇 IOException，会弹出错误提示并记录到 Burp 日志（使用 existing logging）。
